### PR TITLE
Mels platforms branch

### DIFF
--- a/cylc/flow/cfgspec/globalcfg.py
+++ b/cylc/flow/cfgspec/globalcfg.py
@@ -106,8 +106,9 @@ SPEC = {
             'work directory': [VDR.V_STRING],
             'task communication method': [
                 VDR.V_STRING, 'default', 'ssh', 'poll'],
-            'submission polling intervals': [VDR.V_INTERVAL_LIST],
             'execution polling intervals': [VDR.V_INTERVAL_LIST],  # *******
+            'execution retry delays': [VDR.V_INTERVAL_LIST, None],
+            'execution time limit': [VDR.V_INTERVAL],
             'scp command': [VDR.V_STRING],
             'ssh command': [VDR.V_STRING],
             'use login shell': [VDR.V_BOOLEAN],
@@ -119,10 +120,12 @@ SPEC = {
             'retrieve job logs command': [VDR.V_STRING],
             'retrieve job logs max size': [VDR.V_STRING],
             'retrieve job logs retry delays': [VDR.V_INTERVAL_LIST],
+            'submission polling intervals': [VDR.V_INTERVAL_LIST, None],
+            'submission retry delays': [VDR.V_INTERVAL_LIST, None],
             'task event handler retry delays': [VDR.V_INTERVAL_LIST],
             'tail command template': [VDR.V_STRING],
             'batch system': {
-                'name': [VDR.V_STRING],
+                'name': [VDR.V_STRING, 'background'],
                 'err tailer': [VDR.V_STRING],
                 'out tailer': [VDR.V_STRING],
                 'out viewer': [VDR.V_STRING],
@@ -130,6 +133,7 @@ SPEC = {
                 'job name length maximum': [VDR.V_INTEGER],
                 'execution time limit polling intervals': [
                     VDR.V_INTERVAL_LIST],
+                'submit command template': [VDR.V_STRING],
             },
         },
     },

--- a/cylc/flow/cfgspec/suite.py
+++ b/cylc/flow/cfgspec/suite.py
@@ -170,6 +170,10 @@ SPEC = {
                 'exclude': [VDR.V_STRING_LIST],
             },
             'job': {
+                # TODO This section should have been removed by the end of the
+                # job platforms work, although upgraders should have been
+                # devised such that end users will be able to continue using
+                # them.
                 'batch system': [VDR.V_STRING, 'background'],
                 'batch submit command template': [VDR.V_STRING],
                 'execution polling intervals': [VDR.V_INTERVAL_LIST, None],
@@ -179,6 +183,13 @@ SPEC = {
                 'submission retry delays': [VDR.V_INTERVAL_LIST, None],
             },
             'remote': {
+                # TODO This section should have been removed by the end of the
+                # job platforms work, although upgraders should have been
+                # devised such that end users will be able to continue using
+                # them.
+                # The only items to keep are owner and suite definition
+                # directory and these can probably be at the top level rather
+                # Than in the [[[remote]]] sub-section.
                 'host': [VDR.V_STRING],
                 'owner': [VDR.V_STRING],
                 'suite definition directory': [VDR.V_STRING],

--- a/tests/cylc-get-site-config/05-host-bool-override.t
+++ b/tests/cylc-get-site-config/05-host-bool-override.t
@@ -1,0 +1,52 @@
+#!/bin/bash
+# THIS FILE IS PART OF THE CYLC SUITE ENGINE.
+# Copyright (C) 2008-2019 NIWA & British Crown (Met Office) & Contributors.
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Test site-config host item boolean override (GitHub #2282).
+
+. "$(dirname "$0")/test_header"
+set_test_number 2
+
+mkdir etc/
+cat etc/flow.rc <<'__hi__'
+[job platforms]
+    [[desktop\d\d|laptop\d\d]]
+    [[sugar]]
+        login hosts = localhost
+        batch system = slurm
+    [[hpc]]
+        login hosts = hpcl1, hpcl2
+        retrieve job logs = True
+        batch system = pbs
+    [[hpcl1-bg]]
+        login hosts = hpcl1
+        retrieve job logs = True
+        batch system = background
+    [[hpcl2-bg]]
+        login hosts = hpcl2
+        retrieve job logs = True
+        batch system = background
+__hi__
+
+export CYLC_CONF_PATH="${PWD}/etc"
+
+tree >&2
+
+run_ok "${TEST_NAME_BASE}"  cylc get-global-config
+
+cmp_ok "${TEST_NAME_BASE}.stderr" </dev/null
+
+exit


### PR DESCRIPTION
Some more changes to our combined branch
* Copy config items from `cfgspec/suite.py` - `[runtime][TASK][job]` and `[runtime][TASK][remote]` to the job platforms section of `cfgspec/globalconfig.py`
* Put a note in `cfgspec/suite.py` to remind us that these are to be deprecated.